### PR TITLE
add sqlite3 support/config, take 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ end
 group :development, :test do
   gem 'pry'
   gem 'pry-doc'
+  gem 'sqlite3'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,6 +212,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sqlite3 (1.3.13)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.5)
@@ -267,6 +268,7 @@ DEPENDENCIES
   sprockets
   sprockets-es6
   sprockets-rails
+  sqlite3
   uglifier (>= 1.3.0)
   unicorn
   web-console

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,35 +1,41 @@
 default: &default
-
-development:
-  <<: *default
-  adapter: postgresql
   encoding: unicode
   pool: 5
+
+postgres: &postgres
+  <<: *default
+  adapter: postgresql
+  # host was set to "localhost" (no quotes), but rails console production
+  # needed it to be empty string, as per 
+  # http://stackoverflow.com/questions/32186349/rails-console-no-password-supply-error
   host: ""
-  database: "contradev"
   password: "balance+swing"
+
+sqlite: &sqlite
+  <<: *default
+  adapter: sqlite3
+
+
+# To use sqlite3 for development or testing, change the "postgres" reference to
+# "sqlite" and set the database field to a path to the database file.  E.g.:
+#
+#development:
+#  <<: *sqlite
+#  database: "db/contradev.sqlite3"
+
+development:
+  <<: *postgres
+  database: contradev
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
-  adapter: postgresql
-  encoding: unicode
-  pool: 5
-  host: ""
-  database: "contratest"
-  password: "balance+swing"
+  <<: *postgres
+  database: contratest
 
 production:
-  <<: *default
-  adapter: postgresql
-  encoding: unicode
-  pool: 5
-  # host was set to "localhost" (no quotes), but rails console production
-  # needed it to be empty string, as per 
-  # http://stackoverflow.com/questions/32186349/rails-console-no-password-supply-error
-  host: ""
+  <<: *postgres
   username: rails
   password: <%= ENV['APP_DATABASE_PASSWORD'] %>
   database: app_production


### PR DESCRIPTION
This offers a zero-setup option for development and testing.

Clean new PR updated to not collide with Rails 5 branch, and with configuration merged cleanly into a single `database.yml`, incorporating comments from #198.

(I'd still push for SQLite as the public default for development/testing, so that any would-be contributors can get set up with minimal hassle; someone who both runs a production server and develops would likely have a local configuration to use the same system for both.  It's your call though.)