### PR TITLE
Add shoulder parameter for hey

### DIFF
--- a/app/assets/javascripts/libfigure/figure.es6
+++ b/app/assets/javascripts/libfigure/figure.es6
@@ -379,8 +379,8 @@ defineRelatedMove2Way('gyre star', 'star');
 
 function hey_change(figure,index) {
   var pvs = figure.parameter_values;
-  var half_or_full_idx = 1;
-  var beats_idx = 3;
+  var half_or_full_idx = 2;
+  var beats_idx = 4;
   var half_or_full = pvs[half_or_full_idx];
   var beats = pvs[beats_idx];
   if (half_or_full_idx === index && (half_or_full * beats === 8)) {
@@ -389,16 +389,16 @@ function hey_change(figure,index) {
 }
 
 function hey_view(move,pvs) {
-  var [  who,   half,  dir,  beats] = pvs;
-  var [leader, shalf, sdir, sbeats] = parameter_strings(move, pvs);
+  var [  who,   pass,  half,  dir,  beats] = pvs;
+  var [leader, spass, shalf, sdir, sbeats] = parameter_strings(move, pvs);
   var sdir2 = dir === 'across' ? '' : sdir;
   var tbeats = beats / half === 16 ? '' : ('for '+beats);
   var thalf = (1 === half) ? false : shalf;
-  return words(sdir2, thalf, move, comma, leader, "lead", tbeats);
+  return words(sdir2, thalf, move, comma, leader, spass, tbeats);
 }
 
 defineFigure("hey",
-             [param_subject_pair_ladles, param_half_or_full_half_chatty_half, param_set_direction_across, param_beats_8],
+             [param_subject_pair_ladles, param_pass_on_right, param_half_or_full_half_chatty_half, param_set_direction_across, param_beats_8],
              {view: hey_view, change: hey_change});
 
 

--- a/app/assets/javascripts/libfigure/param.js
+++ b/app/assets/javascripts/libfigure/param.js
@@ -55,7 +55,7 @@ var param_left_shoulder_spin     = {name: "shoulder", value: false, ui: chooser_
 
 
 function stringParamSide (value) {
-  return value ? "passing left sides" : "passing right sides";
+  return value ? "pass right" : "pass left";
 }
 
 function stringParamDegrees (value,move) { 
@@ -110,9 +110,8 @@ var param_object_pairs               = {name: "whom",                       ui: 
 var param_object_pairs_or_ones_or_twos = {name: "whom",                     ui: chooser_pairs_or_ones_or_twos};
 var param_lead_dancer_l1             = {name: "lead", value: "first ladle", ui: chooser_dancer};
 
-// not used anymore
-// param_pass_on_left = {name: "pass", value: false, ui: chooser_right_left_shoulder};
-// param_pass_on_right = {name: "pass", value: true, ui: chooser_right_left_shoulder};
+var param_pass_on_left = {name: "pass", value: false, ui: chooser_right_left_shoulder, string: stringParamSide};
+var param_pass_on_right = {name: "pass", value: true, ui: chooser_right_left_shoulder, string: stringParamSide};
 
 var param_custom_figure = {name: "custom", value: "", ui: chooser_text};
 

--- a/db/migrate/20171018234351_hey_add_shoulder.rb
+++ b/db/migrate/20171018234351_hey_add_shoulder.rb
@@ -1,0 +1,32 @@
+require 'jslibfigure'
+
+class HeyAddShoulder < ActiveRecord::Migration
+  def down
+    raise 'too lazy to implement down'
+  end
+  def up
+    count = 0
+    Dance.all.each do |dance|
+      oldfigures = dance.figures
+      newfigures = oldfigures.map do |figure|
+        move = JSLibFigure.move(figure)
+        oldpvs = figure['parameter_values']
+        if move == 'hey'
+          newpvs = oldpvs.clone.unshift(oldpvs.first)
+          newpvs[1] = true
+          figure.merge('parameter_values' => newpvs)
+        else
+          figure
+        end
+      end
+      unless oldfigures == newfigures
+        count += 1
+        dance.record_timestamps = false
+        dance.update!(figures: newfigures) 
+        puts "#{dance.title} (#{dance.id})"
+      end
+    end
+    puts "#{count}/#{Dance.all.count} dances updated"
+
+  end
+end


### PR DESCRIPTION
Replaces "lead" with "pass right/left" to indicate how the hey-leaders
should lead.  DB migration script included.

Implements #213.